### PR TITLE
Validate JSON tables before loading

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -40,7 +40,8 @@ async function loadAllTables() {
       const json = JSON.parse(buf);
 
       // einfache Strukturprüfung (EG-Schlüssel erwartet)
-      if (typeof json !== "object" || Array.isArray(json)) {
+      // JSON.parse kann `null` zurückgeben, was ebenfalls kein gültiges Tabellen-Objekt ist
+      if (json === null || typeof json !== "object" || Array.isArray(json)) {
         throw new Error(`Ungültiges JSON-Format in ${file}`);
       }
       map[key] = json;


### PR DESCRIPTION
## Summary
- Guard against `null` when loading table JSON files to ensure only valid objects are accepted

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6899fc8c613483229d6a7382d619e45f