### PR TITLE
chore(api): adjust fs.watch debounce wording

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -64,7 +64,7 @@ loadAllTables().catch(console.error);
 try {
   fs.watch(DATA_DIR, { persistent: true }, (event, filename) => {
     if (!filename || !filename.endsWith(".json")) return;
-    // Debounce: kleinen Timeout, falls Editor zweimal schreibt
+    // Debounce: kurzen Timeout, falls Editor zweimal schreibt
     clearTimeout(fs.watch._t);
     fs.watch._t = setTimeout(() => loadAllTables().catch(console.error), 150);
   });


### PR DESCRIPTION
## Summary
- adjust fs.watch debounce comment to use "kurzen Timeout"

## Testing
- `npm test --prefix api` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a014db4348322a05939e70c64d7e8