### PR TITLE
Handle decimal separators in comparison

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -212,7 +212,7 @@ document.addEventListener("DOMContentLoaded", () => {
     els.cmpNowMonth.textContent = fmtEUR.format(t.monat);
     els.cmpNowYear.textContent  = fmtEUR.format(t.jahr);
     els.cmpNowAvg.textContent   = fmtEUR.format(t.durchschnittMonat);
-    const p = s => Number(String(s).replace(/[^\d,.-]/g,'').replace('.', '').replace(',', '.'));
+    const p = s => Number(String(s).replace(/[^\d,.-]/g,'').replace(/\./g, '').replace(',', '.'));
     const dM = p(els.cmpNowMonth.textContent)-p(snap.month);
     const dY = p(els.cmpNowYear.textContent)-p(snap.year);
     const dA = p(els.cmpNowAvg.textContent)-p(snap.avg);


### PR DESCRIPTION
## Summary
- Ensure `maybeCompare` removes all dots before converting commas to dots for number parsing

## Testing
- `npm test` *(fails: no package.json)*
- `(cd api && npm test)` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a4d2b08788322b1f5da87749da63a