### PR TITLE
Vereinfache Urlaubstage Eingabe

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -86,7 +86,7 @@ function getTable(key) {
 function calculate(input) {
   const {
     tariffDate, eg, stufe, irwazHours, leistungsPct,
-    urlaubsanspruchTage, urlaubstage, betriebsMonate, tZugBPeriod
+    urlaubstage, betriebsMonate, tZugBPeriod
   } = input;
 
   const tbl = getTable(tariffDate);
@@ -124,9 +124,9 @@ function calculate(input) {
   const pTZUGB = (tZugBPeriod === "from2026") ? 26.5 : 18.5;
   const tZugB = baseTbl.EG05.B * (pTZUGB / 100);
 
-  const uansp = urlaubsanspruchTage;
   const utage = urlaubstage;
-  const utag = (uansp && utage) ? (((grund + bonus) / 65.25) * 1.5 * (30 / uansp)) : 0;
+  const uansp = urlaubstage;
+  const utag = utage ? (((grund + bonus) / 65.25) * 1.5 * (30 / uansp)) : 0;
   const uges = utag * utage;
 
   const gesMon = grund + bonus;
@@ -164,8 +164,7 @@ const CalcSchema = z.object({
   stufe: z.string().optional(),           // nur benötigt, wenn EG gestuft ist
   irwazHours: z.number().min(0).max(48),
   leistungsPct: z.number().min(0).max(28),
-  urlaubsanspruchTage: z.number().int().min(20).max(40),
-  urlaubstage: z.number().int().min(0).max(30),
+  urlaubstage: z.number().int().min(0).max(36),
   betriebsMonate: z.number().int().min(0).max(480),
   tZugBPeriod: z.enum(["until2025","from2026"])
 });

--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -5,7 +5,7 @@ document.addEventListener("DOMContentLoaded", () => {
     tariffDate: $("tariffDate"), eg: $("egSelect"), stufeWrap: $("stufeWrap"), stufe: $("stufeSelect"),
     irwaz: $("irwazHours"), irwazRange: $("irwazRange"),
     leistung: $("leistungsPct"), leistungRange: $("leistungsRange"),
-    uAnspr: $("urlaubsanspruchTage"), uTage: $("urlaubstage"), uTageRange: $("urlaubstageRange"),
+    uTage: $("urlaubstage"), uTageRange: $("urlaubstageRange"),
     betriebs: $("betriebsMonate"), period: $("tZugBPeriod"),
     status: $("status"), tablesInfo: $("tablesInfo"),
     irwazBadge: $("irwazBadge"), leistungBadge: $("leistungBadge"), urlaubBadge: $("urlaubBadge"),
@@ -70,7 +70,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // Recalc on input (debounced)
     const recalc = debounce(calculate, 120);
     [els.tariffDate, els.eg, els.stufe, els.irwaz, els.irwazRange, els.leistung, els.leistungRange,
-     els.uAnspr, els.uTage, els.uTageRange, els.betriebs, els.period]
+     els.uTage, els.uTageRange, els.betriebs, els.period]
      .forEach(el => el && el.addEventListener("input", recalc));
 
     els.tariffDate.addEventListener("change", async () => {
@@ -132,7 +132,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const payload = {
       tariffDate: els.tariffDate.value, eg: els.eg.value, stufe: els.stufe.value || undefined,
       irwazHours: Number(els.irwaz.value), leistungsPct: Number(els.leistung.value),
-      urlaubsanspruchTage: Number(els.uAnspr.value), urlaubstage: Number(els.uTage.value),
+      urlaubstage: Number(els.uTage.value),
       betriebsMonate: Number(els.betriebs.value), tZugBPeriod: els.period.value
     };
     setStatus("Berechne…","muted");
@@ -186,7 +186,7 @@ document.addEventListener("DOMContentLoaded", () => {
     return {
       tariffDate: els.tariffDate.value, eg: els.eg.value, stufe: els.stufe.value || undefined,
       irwazHours: Number(els.irwaz.value), leistungsPct: Number(els.leistung.value),
-      urlaubsanspruchTage: Number(els.uAnspr.value), urlaubstage: Number(els.uTage.value),
+      urlaubstage: Number(els.uTage.value),
       betriebsMonate: Number(els.betriebs.value), tZugBPeriod: els.period.value
     };
   }
@@ -223,8 +223,8 @@ document.addEventListener("DOMContentLoaded", () => {
   function resetForm(){
     els.irwaz.value = els.irwazRange.value = 35;
     els.leistung.value = els.leistungRange.value = 0;
-    els.uAnspr.value = "30";
-    els.uTage.value = els.uTageRange.value = 0;
+    els.uTage.value = els.uTageRange.value = 30;
+    els.urlaubBadge.textContent = `${Number(els.uTage.value)} Tage`;
     els.betriebs.value = "0";
     els.period.value = "until2025";
     calculate(); toast("Formular zurückgesetzt");

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -84,23 +84,14 @@
         </div>
       </div>
 
-      <div class="field two">
-        <div>
-          <label for="urlaubsanspruchTage">Urlaubsanspruch (Tage)</label>
-          <select id="urlaubsanspruchTage">
-            <option>20</option><option>25</option><option selected>30</option>
-            <option>35</option><option>40</option>
-          </select>
+      <div class="field">
+        <div class="label-row">
+          <label for="urlaubstage">Urlaubstage</label>
+          <span class="badge" id="urlaubBadge">30 Tage</span>
         </div>
-        <div>
-          <div class="label-row">
-            <label for="urlaubstage">Urlaubstage für Berechnung</label>
-            <span class="badge" id="urlaubBadge">0 Tage</span>
-          </div>
-          <div class="combo">
-            <input id="urlaubstage" type="number" min="0" max="30" step="1" value="0" />
-            <input id="urlaubstageRange" class="range" type="range" min="0" max="30" step="1" value="0" />
-          </div>
+        <div class="combo">
+          <input id="urlaubstage" type="number" min="0" max="36" step="1" value="30" />
+          <input id="urlaubstageRange" class="range" type="range" min="0" max="36" step="1" value="30" />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Kombiniere Urlaubsanspruch und Berechnungstage zu einem Regler mit 0–36 Tagen (Standard 30)
- Entferne `urlaubsanspruchTage` aus Frontend- und Backend-Logik
- Passe API-Validierung und Berechnungen an die neue Eingabe an

## Testing
- `npm test --prefix api` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b0bdb34c48322aa82eb3e3adbc2ee