### PR TITLE
chore: remove git clone from upgrade script

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+# ensure running with sudo/root
+if [ "$EUID" -ne 0 ]; then
+  echo "Dieses Skript muss mit sudo ausgeführt werden." >&2
+  exit 1
+fi
+
+read -p "Wo sollen die Frontend-Dateien installiert werden? " FRONTEND_DIR
+read -p "Wo sollen die API-Dateien installiert werden? " API_DIR
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# copy frontend and api
+mkdir -p "$FRONTEND_DIR" "$API_DIR"
+rsync -a "$REPO_DIR/frontend/" "$FRONTEND_DIR/"
+rsync -a "$REPO_DIR/api/" "$API_DIR/"
+
+chown -R www-data:www-data "$FRONTEND_DIR" "$API_DIR"
+chmod -R 775 "$FRONTEND_DIR" "$API_DIR"
+
+echo "Upgrade abgeschlossen."


### PR DESCRIPTION
## Summary
- simplify upgrade script to copy from current repository instead of cloning

## Testing
- `cd api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b4d9ed7d48322943e56e825ec7acd