### PR TITLE
feat(frontend): add apprenticeship mode and formatted tariff dates

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,11 +44,20 @@
         <label for="tariffDate">Tarifdatum</label>
         <select id="tariffDate"></select>
         <p class="hint small" id="tablesInfo">—</p>
+        <p class="hint small hidden" id="azubiHint">Hinweis: Die Auszubildendenvergütung 2025 gilt ab 01. Januar 2025.</p>
+      </div>
+
+      <div class="field">
+        <label for="ausbildung">In Ausbildung?</label>
+        <select id="ausbildung">
+          <option value="nein" selected>Nein</option>
+          <option value="ja">Ja</option>
+        </select>
       </div>
 
       <div class="field two">
-        <div>
-          <label for="egSelect">Entgeltgruppe</label>
+        <div id="egWrap">
+          <label for="egSelect" id="egLabel">Entgeltgruppe</label>
           <select id="egSelect"></select>
         </div>
         <div id="stufeWrap" class="hidden">


### PR DESCRIPTION
## Summary
- format tariff date options like "01. Mai 2024"
- add Ausbildung toggle that loads AJ1-4 groups and shows hint for 2025
- auto-set Betriebszugehörigkeit for apprenticeship levels

## Testing
- `cd api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bd5cc2318832283c2413ac41aa0d1