### PR TITLE
Improve mobile layout and streamline UI

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
     status: $("status"), tablesInfo: $("tablesInfo"), azubiHint: $("azubiHint"),
     irwazBadge: $("irwazBadge"), leistungBadge: $("leistungBadge"), urlaubBadge: $("urlaubBadge"),
     result: $("result"),
-    calcBtn: $("calcBtn"), resetBtn: $("resetBtn"), snapshotBtn: $("snapshotBtn"), clearSnapshotBtn: $("clearSnapshotBtn"),
+    resetBtn: $("resetBtn"), snapshotBtn: $("snapshotBtn"), clearSnapshotBtn: $("clearSnapshotBtn"),
     compareWrap: $("compare"), cmpNowMonth: $("cmpNowMonth"), cmpNowYear: $("cmpNowYear"), cmpNowAvg: $("cmpNowAvg"),
     cmpSnapMonth: $("cmpSnapMonth"), cmpSnapYear: $("cmpSnapYear"), cmpSnapAvg: $("cmpSnapAvg"),
     cmpDeltaMonth: $("cmpDeltaMonth"), cmpDeltaYear: $("cmpDeltaYear"), cmpDeltaAvg: $("cmpDeltaAvg"),
@@ -104,7 +104,6 @@ document.addEventListener("DOMContentLoaded", () => {
       recalc();
     });
 
-    els.calcBtn.addEventListener("click", calculate);
     els.resetBtn.addEventListener("click", resetForm);
     els.snapshotBtn.addEventListener("click", saveSnapshot);
     els.clearSnapshotBtn.addEventListener("click", clearSnapshot);

--- a/frontend/assets/style.css
+++ b/frontend/assets/style.css
@@ -35,12 +35,19 @@ body{
 }
 
 /* ==== Layout ==== */
+
 .container{max-width:1120px;margin:0 auto;padding:20px}
+@media (max-width:560px){.container{padding:14px}}
 .main-grid{display:grid;grid-template-columns:1.05fr .95fr;gap:20px}
 @media (max-width: 980px){.main-grid{grid-template-columns:1fr}}
 
 .site-header{border-bottom:1px solid var(--line); background:linear-gradient(135deg, rgba(16,24,62,.65), rgba(12,31,42,0))}
 .header-bar{display:flex;align-items:center;justify-content:space-between;gap:16px}
+.header-actions{display:flex;align-items:center;gap:10px}
+@media (max-width:560px){
+  .header-bar{flex-direction:column;align-items:flex-start}
+  .header-actions{width:100%;justify-content:space-between}
+}
 .brand{display:flex;align-items:center;gap:14px}
 .logo{display:grid;place-items:center;height:42px;width:42px;border-radius:12px;background:linear-gradient(135deg,var(--accent1),var(--accent2));box-shadow:var(--shadow)}
 h1{font-size:1.25rem;margin:0}
@@ -82,8 +89,12 @@ input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
 input[type=range]::-moz-range-thumb{height:18px;width:18px;border-radius:50%;background:#fff;border:3px solid var(--accent1);cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,.3)}
 
 /* ==== Buttons ==== */
-.actions{display:flex;gap:10px;margin-top:14px;align-items:center}
+.actions{display:flex;gap:10px;margin-top:14px;align-items:center;flex-wrap:wrap}
 .spacer{flex:1}
+@media (max-width:560px){
+  .actions{flex-direction:column;align-items:stretch}
+  .actions .spacer{display:none}
+}
 .btn{background:linear-gradient(135deg,var(--accent1),var(--accent2));color:#071024;border:none;font-weight:700;cursor:pointer;box-shadow:var(--shadow)}
 .btn:hover{transform:translateY(-1px)}
 .btn:active{transform:translateY(0)}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -118,7 +118,6 @@
       </div>
 
       <div class="actions">
-        <button id="calcBtn" class="btn">Berechnen</button>
         <button id="resetBtn" class="btn ghost" type="button">Zurücksetzen</button>
         <div class="spacer"></div>
         <button id="snapshotBtn" class="btn subtle" type="button">Snapshot speichern</button>


### PR DESCRIPTION
## Summary
- Refine header and action layouts for better mobile responsiveness
- Remove the now-unnecessary Berechnen button to rely on live recalculation
- Ensure button row wraps cleanly on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bddc19038832298d2efe27d019b63