### PR TITLE
Hide bonus when Ausbildung selected

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -136,24 +136,29 @@ function calculate(input) {
   const gesMon = gesMonBasis + kinderZulage;
   const gesJahr = gesMonBasis * 12 + kinderZulage * 12 + mon13 + tGeld + tZugA + tZugB + uges;
 
+  const breakdown = {
+    grund35: euro(grund35),
+    irwazHours,
+    grund: euro(grund),
+    kinderzulage: euro(kinderZulage),
+    p13,
+    mon13: euro(mon13),
+    tGeld: euro(tGeld),
+    tZugA: euro(tZugA),
+    tZugB: euro(tZugB),
+    urlaub: {
+      entgeltProTag: euro(utag),
+      tage: utage,
+      gesamt: euro(uges)
+    }
+  };
+
+  if (!isAzubi) {
+    breakdown.bonus = euro(bonus);
+  }
+
   return {
-    breakdown: {
-      grund35: euro(grund35),
-      irwazHours,
-      grund: euro(grund),
-      bonus: euro(bonus),
-      kinderzulage: euro(kinderZulage),
-      p13,
-      mon13: euro(mon13),
-      tGeld: euro(tGeld),
-      tZugA: euro(tZugA),
-      tZugB: euro(tZugB),
-      urlaub: {
-        entgeltProTag: euro(utag),
-        tage: utage,
-        gesamt: euro(uges)
-      }
-    },
+    breakdown,
     totals: {
       monat: euro(gesMon),
       jahr: euro(gesJahr),

--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -277,10 +277,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function renderResult(d){
     const b = d.breakdown, t = d.totals;
+    const bonusTxt = b.bonus !== undefined ? ` · Bonus: ${fmtEUR.format(b.bonus)}` : "";
+    const kinderTxt = b.kinderzulage ? ` · Zulage: ${fmtEUR.format(b.kinderzulage)}` : "";
     els.result.innerHTML = `
       <div class="subgrid">
         <div class="tile"><h3>Monat</h3><div class="big">${fmtEUR.format(t.monat)}</div>
-          <div class="micro muted">Grund: ${fmtEUR.format(b.grund)} · Bonus: ${fmtEUR.format(b.bonus)}${b.kinderzulage ? ` · Zulage: ${fmtEUR.format(b.kinderzulage)}` : ""}</div></div>
+          <div class="micro muted">Grund: ${fmtEUR.format(b.grund)}${bonusTxt}${kinderTxt}</div></div>
         <div class="tile"><h3>Jahr</h3><div class="big">${fmtEUR.format(t.jahr)}</div>
           <div class="micro muted">Ø Monat: ${fmtEUR.format(t.durchschnittMonat)}</div></div>
         <div class="tile">


### PR DESCRIPTION
## Summary
- omit bonus from API breakdown for trainees
- render result without bonus line when Ausbildung is selected

## Testing
- `cd api && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689c7ecba028832293de44329af5a1ff