### PR TITLE
Harden authentication and client rendering

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "entgeltrechner-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entgeltrechner-api",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.0.0",
         "helmet": "^8.1.0",
         "morgan": "^1.10.1",
         "zod": "^4.0.17"
@@ -2040,6 +2041,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "audit": "npm audit"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +13,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.0.0",
     "helmet": "^8.1.0",
     "morgan": "^1.10.1",
     "zod": "^4.0.17"

--- a/frontend/assets/change-password.js
+++ b/frontend/assets/change-password.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('pwChangeBtn');
   const err = document.getElementById('pwChangeError');
   const logoutBtn = document.getElementById('logoutBtn');
-  let token = localStorage.getItem('token') || '';
+  let token = sessionStorage.getItem('token') || '';
   if (!token) { window.location.href = '/'; return; }
 
   async function fetchJSON(url, opts = {}) {
@@ -19,8 +19,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     if (r.status === 401) {
       token = '';
-      localStorage.removeItem('token');
-      localStorage.removeItem('isAdmin');
+      sessionStorage.removeItem('token');
+      sessionStorage.removeItem('isAdmin');
       window.location.href = '/';
       throw new Error('Unauthorized');
     }
@@ -35,8 +35,8 @@ document.addEventListener('DOMContentLoaded', () => {
   async function logout(){
     try { await fetch('/api/logout', { method:'POST', headers:{ Authorization: `Bearer ${token}` } }); } catch {}
     token='';
-    localStorage.removeItem('token');
-    localStorage.removeItem('isAdmin');
+    sessionStorage.removeItem('token');
+    sessionStorage.removeItem('isAdmin');
     window.location.href = '/';
   }
 


### PR DESCRIPTION
## Summary
- Enforce robust password complexity and username validation on registration and login
- Secure token handling and DOM updates in frontend to reduce XSS risk
- Add rate limiting, session cleanup, stricter headers, and audit script

## Testing
- `npm test`
- `npm run audit`


------
https://chatgpt.com/codex/tasks/task_e_689de4f81b2c8322a3c14d46233573bf